### PR TITLE
Initial OpenAPI prototype from first working session

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Eclipse Marketplace API v2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.modelsolv.reprezen.zenNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# marketplace-rest-api-specs
+# Eclipse Marketplace REST API Specifications
+
+This project contains a working prototype of the next-generation REST API for the [Eclipse Marketplace](https://marketplace.eclipse.org). The Eclipse Marketplace provides thousands of plug-ins, solutions, and service offerings for the the Eclipse community. And the new REST API will provide intuitive, flexible access to essential Marketplace listings, metrics, and activity. 
+
+# OpenAPI Specification, Documentation, and Client Libraries
+
+The API is specified in this [OpenAPI 3.0 document](/models/Eclipse%20Marketplace%20API%20Specification.yaml). 
+
+We will be publishing complete API documentation and client libraries on a developer portal, coming soon.
+
+# Development Environment
+
+The core specification in the [models folder](/models) is in standard OpenAPI 3.0 YAML format, and can be edited with any [avaiable OpenAPI 3.0 editor](https://openapi.tools).
+
+Generators in the [gentargets folder](/gentargets) are a representative sample of service implementation scaffolds, client SDK libraries,  and documentation formats. These are created using the RepreZen/GenFlow framework with open source generators from RepreZen and OpenAPI-Tools/OpenAPI-Generator. You can use the included Maven and Gradle configuration files to generate these artifacts. 
+
+The overall project is set up using [RepreZen API Studio for Eclipse](https://marketplace.eclipse.org/content/reprezen-api-studio), available on the Eclipse Marketplace for installation into a standard Eclipse IDE, or [API Studio Desktop](http://RZen.io/InstallOptions), a self-contained Eclipse RCP distribution. 

--- a/gentargets/Eclipse Marketplace API Specification/Android Client/Android Client.gen
+++ b/gentargets/Eclipse Marketplace API Specification/Android Client/Android Client.gen
@@ -1,0 +1,76 @@
+---
+name: "Android Client"
+genTemplateId: "com.reprezen.genflow.openapi.generator.AndroidClientCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # Sort method arguments to place required parameters before optional parameters.
+  sortParamsByRequiredFlag: null
+  
+  # Whether to ensure parameter names are unique in an operation (rename parameters that are not).
+  ensureUniqueParams: null
+  
+  # boolean, toggles whether unicode identifiers are allowed in names or not, default is false
+  allowUnicodeIdentifiers: null
+  
+  # Add form or body parameters to the beginning of the parameter list.
+  prependFormOrBodyParameters: null
+  
+  # package for generated models
+  modelPackage: null
+  
+  # package for generated api classes
+  apiPackage: null
+  
+  # root package for generated code
+  invokerPackage: null
+  
+  # groupId for use in the generated build.gradle and pom.xml
+  groupId: null
+  
+  # artifactId for use in the generated build.gradle and pom.xml
+  artifactId: null
+  
+  # artifact version for use in the generated build.gradle and pom.xml
+  artifactVersion: null
+  
+  # source folder for generated code
+  sourceFolder: null
+  
+  # A flag to toggle android-maven gradle plugin.
+  useAndroidMavenGradlePlugin: null
+  
+  # gradleVersion version for use in the generated build.gradle
+  androidGradleVersion: null
+  
+  # compileSdkVersion version for use in the generated build.gradle
+  androidSdkVersion: null
+  
+  # buildToolsVersion version for use in the generated build.gradle
+  androidBuildToolsVersion: null
+  
+  # boolean - toggle "implements Serializable" for generated models
+  serializableModel: null
+  
+  # library template (sub-template) to use
+  library: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/Android Client/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/Android Client/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\Android Client\\Android Client.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/Android Client/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/Android Client/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>android-client</artifactId>
+	<name>GenTarget Launcher For Android Client</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>Android Client</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/C# ASP.Net Core Server/C# ASP.Net Core Server.gen
+++ b/gentargets/Eclipse Marketplace API Specification/C# ASP.Net Core Server/C# ASP.Net Core Server.gen
@@ -1,0 +1,55 @@
+---
+name: "C# ASP.Net Core Server"
+genTemplateId: "com.reprezen.genflow.openapi.generator.AspNetCoreServerCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # C# package name (convention: Title.Case).
+  packageName: null
+  
+  # C# package version.
+  packageVersion: null
+  
+  # The GUID that will be associated with the C# project
+  packageGuid: null
+  
+  # source folder for generated code
+  sourceFolder: null
+  
+  # ASP.NET Core version: 2.1 (default), 2.0 (deprecated)
+  aspnetCoreVersion: null
+  
+  # Sort method arguments to place required parameters before optional parameters.
+  sortParamsByRequiredFlag: null
+  
+  # Use DateTimeOffset to model date-time properties
+  useDateTimeOffset: null
+  
+  # Deserialize array types to Collection<T> instead of List<T>.
+  useCollection: null
+  
+  # Return ICollection<T> instead of the concrete type.
+  returnICollection: null
+  
+  # Uses the Swashbuckle.AspNetCore NuGet package for documentation.
+  useSwashbuckle: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/C# ASP.Net Core Server/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/C# ASP.Net Core Server/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\C# ASP.Net Core Server\\C# ASP.Net Core Server.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/C# ASP.Net Core Server/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/C# ASP.Net Core Server/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>c--asp-net-core-server</artifactId>
+	<name>GenTarget Launcher For C# ASP.Net Core Server</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>C# ASP.Net Core Server</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/C# Client/C# Client.gen
+++ b/gentargets/Eclipse Marketplace API Specification/C# Client/C# Client.gen
@@ -1,0 +1,88 @@
+---
+name: "C# Client"
+genTemplateId: "com.reprezen.genflow.openapi.generator.CSharpClientCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # C# package name (convention: Title.Case).
+  packageName: null
+  
+  # C# package version.
+  packageVersion: null
+  
+  # source folder for generated code
+  sourceFolder: null
+  
+  # The GUID that will be associated with the C# project
+  packageGuid: null
+  
+  # Prefix interfaces with a community standard or widely accepted prefix.
+  interfacePrefix: null
+  
+  # The target .NET framework version.
+  targetFramework: null
+  
+  # Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name
+  modelPropertyNaming: null
+  
+  # Hides the generation timestamp when files are generated.
+  hideGenerationTimestamp: null
+  
+  # Sort method arguments to place required parameters before optional parameters.
+  sortParamsByRequiredFlag: null
+  
+  # Use DateTimeOffset to model date-time properties
+  useDateTimeOffset: null
+  
+  # Deserialize array types to Collection<T> instead of List<T>.
+  useCollection: null
+  
+  # Return ICollection<T> instead of the concrete type.
+  returnICollection: null
+  
+  # C# Optional method argument, e.g. void square(int x=10) (.net 4.0+ only).
+  optionalMethodArgument: null
+  
+  # Generate AssemblyInfo.cs.
+  optionalAssemblyInfo: null
+  
+  # Generate {PackageName}.csproj.
+  optionalProjectFile: null
+  
+  # Set DataMember's EmitDefaultValue.
+  optionalEmitDefaultValues: null
+  
+  # Specifies a AssemblyDescription for the .NET Framework global assembly attributes stored in the AssemblyInfo file.
+  generatePropertyChanged: null
+  
+  # Generates code with reduced access modifiers; allows embedding elsewhere without exposing non-public API calls to consumers.
+  nonPublicApi: null
+  
+  # boolean, toggles whether unicode identifiers are allowed in names or not, default is false
+  allowUnicodeIdentifiers: null
+  
+  # Use the new format (.NET Core) for .NET project files (.csproj).
+  netCoreProjectFile: null
+  
+  # Generates self-validatable models.
+  validatable: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/C# Client/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/C# Client/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\C# Client\\C# Client.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/C# Client/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/C# Client/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>c--client</artifactId>
+	<name>GenTarget Launcher For C# Client</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>C# Client</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/Java Client/Java Client.gen
+++ b/gentargets/Eclipse Marketplace API Specification/Java Client/Java Client.gen
@@ -1,0 +1,166 @@
+---
+name: "Java Client"
+genTemplateId: "com.reprezen.genflow.openapi.generator.JavaClientCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # Sort method arguments to place required parameters before optional parameters.
+  sortParamsByRequiredFlag: null
+  
+  # Whether to ensure parameter names are unique in an operation (rename parameters that are not).
+  ensureUniqueParams: null
+  
+  # boolean, toggles whether unicode identifiers are allowed in names or not, default is false
+  allowUnicodeIdentifiers: null
+  
+  # Add form or body parameters to the beginning of the parameter list.
+  prependFormOrBodyParameters: null
+  
+  # package for generated models
+  modelPackage: null
+  
+  # package for generated api classes
+  apiPackage: null
+  
+  # root package for generated code
+  invokerPackage: null
+  
+  # groupId in generated pom.xml
+  groupId: null
+  
+  # artifactId in generated pom.xml
+  artifactId: null
+  
+  # artifact version in generated pom.xml
+  artifactVersion: null
+  
+  # artifact URL in generated pom.xml
+  artifactUrl: null
+  
+  # artifact description in generated pom.xml
+  artifactDescription: null
+  
+  # SCM connection in generated pom.xml
+  scmConnection: null
+  
+  # SCM developer connection in generated pom.xml
+  scmDeveloperConnection: null
+  
+  # SCM URL in generated pom.xml
+  scmUrl: null
+  
+  # developer name in generated pom.xml
+  developerName: null
+  
+  # developer email in generated pom.xml
+  developerEmail: null
+  
+  # developer organization in generated pom.xml
+  developerOrganization: null
+  
+  # developer organization URL in generated pom.xml
+  developerOrganizationUrl: null
+  
+  # The name of the license
+  licenseName: null
+  
+  # The URL of the license
+  licenseUrl: null
+  
+  # source folder for generated code
+  sourceFolder: null
+  
+  # prefix for generated code members and local variables
+  localVariablePrefix: null
+  
+  # boolean - toggle "implements Serializable" for generated models
+  serializableModel: null
+  
+  # Treat BigDecimal values as Strings to avoid precision loss.
+  bigDecimalAsString: null
+  
+  # whether to use fully qualified name for classes under java.util. This option only works for Java API client
+  fullJavaUtil: null
+  
+  # hides the timestamp when files were generated
+  hideGenerationTimestamp: null
+  
+  # whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)
+  withXml: null
+  
+  # Option. Date library to use
+  dateLibrary: null
+  
+  # Option. Use Java8 classes instead of third party equivalents
+  java8: null
+  
+  # Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)
+  disableHtmlEscaping: null
+  
+  # Set booleanGetterPrefix (default value 'get')
+  booleanGetterPrefix: null
+  
+  # parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+  parentGroupId: null
+  
+  # parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+  parentArtifactId: null
+  
+  # parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+  parentVersion: null
+  
+  # Whether to use the RxJava adapter with the retrofit2 library.
+  useRxJava: null
+  
+  # Whether to use the RxJava2 adapter with the retrofit2 library.
+  useRxJava2: null
+  
+  # Whether to generate models for Android that implement Parcelable with the okhttp-gson library.
+  parcelableModel: null
+  
+  # Use Play! Async HTTP client (Play WS API)
+  usePlayWS: null
+  
+  # Version of Play! Framework (possible values "play24", "play25" (default), "play26")
+  playVersion: null
+  
+  # Whether to support Java6 with the Jersey1 library.
+  supportJava6: null
+  
+  # Use BeanValidation API annotations
+  useBeanValidation: null
+  
+  # Perform BeanValidation
+  performBeanValidation: null
+  
+  # Send gzip-encoded requests
+  useGzipFeature: null
+  
+  # Use RuntimeException instead of Exception
+  useRuntimeException: null
+  
+  # Version of OpenFeign: '10.x', '9.x' (default)
+  feignVersion: null
+  
+  # library template (sub-template) to use
+  library: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/Java Client/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/Java Client/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\Java Client\\Java Client.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/Java Client/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/Java Client/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>java-client</artifactId>
+	<name>GenTarget Launcher For Java Client</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>Java Client</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/Java Jersey (JAX-RS) Server/Java Jersey (JAX-RS) Server.gen
+++ b/gentargets/Eclipse Marketplace API Specification/Java Jersey (JAX-RS) Server/Java Jersey (JAX-RS) Server.gen
@@ -1,0 +1,151 @@
+---
+name: "Java Jersey (JAX-RS) Server"
+genTemplateId: "com.reprezen.genflow.openapi.generator.JavaJerseyServerCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # Sort method arguments to place required parameters before optional parameters.
+  sortParamsByRequiredFlag: null
+  
+  # Whether to ensure parameter names are unique in an operation (rename parameters that are not).
+  ensureUniqueParams: null
+  
+  # boolean, toggles whether unicode identifiers are allowed in names or not, default is false
+  allowUnicodeIdentifiers: null
+  
+  # Add form or body parameters to the beginning of the parameter list.
+  prependFormOrBodyParameters: null
+  
+  # package for generated models
+  modelPackage: null
+  
+  # package for generated api classes
+  apiPackage: null
+  
+  # root package for generated code
+  invokerPackage: null
+  
+  # groupId in generated pom.xml
+  groupId: null
+  
+  # artifactId in generated pom.xml
+  artifactId: null
+  
+  # artifact version in generated pom.xml
+  artifactVersion: null
+  
+  # artifact URL in generated pom.xml
+  artifactUrl: null
+  
+  # artifact description in generated pom.xml
+  artifactDescription: null
+  
+  # SCM connection in generated pom.xml
+  scmConnection: null
+  
+  # SCM developer connection in generated pom.xml
+  scmDeveloperConnection: null
+  
+  # SCM URL in generated pom.xml
+  scmUrl: null
+  
+  # developer name in generated pom.xml
+  developerName: null
+  
+  # developer email in generated pom.xml
+  developerEmail: null
+  
+  # developer organization in generated pom.xml
+  developerOrganization: null
+  
+  # developer organization URL in generated pom.xml
+  developerOrganizationUrl: null
+  
+  # The name of the license
+  licenseName: null
+  
+  # The URL of the license
+  licenseUrl: null
+  
+  # source folder for generated code
+  sourceFolder: null
+  
+  # prefix for generated code members and local variables
+  localVariablePrefix: null
+  
+  # boolean - toggle "implements Serializable" for generated models
+  serializableModel: null
+  
+  # Treat BigDecimal values as Strings to avoid precision loss.
+  bigDecimalAsString: null
+  
+  # whether to use fully qualified name for classes under java.util. This option only works for Java API client
+  fullJavaUtil: null
+  
+  # hides the timestamp when files were generated
+  hideGenerationTimestamp: null
+  
+  # whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)
+  withXml: null
+  
+  # Option. Date library to use
+  dateLibrary: null
+  
+  # Option. Use Java8 classes instead of third party equivalents
+  java8: null
+  
+  # Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)
+  disableHtmlEscaping: null
+  
+  # Set booleanGetterPrefix (default value 'get')
+  booleanGetterPrefix: null
+  
+  # parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+  parentGroupId: null
+  
+  # parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+  parentArtifactId: null
+  
+  # parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+  parentVersion: null
+  
+  # folder for generated implementation code
+  implFolder: null
+  
+  # a title describing the application
+  title: null
+  
+  # Use BeanValidation API annotations
+  useBeanValidation: null
+  
+  # The port on which the server should be started
+  serverPort: null
+  
+  # library template (sub-template) to use
+  library: null
+  
+  # Whether to support Java6 with the Jersey1/2 library.
+  supportJava6: null
+  
+  # use tags for creating interface and controller classnames
+  useTags: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/Java Jersey (JAX-RS) Server/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/Java Jersey (JAX-RS) Server/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\Java Jersey (JAX-RS) Server\\Java Jersey (JAX-RS) Server.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/Java Jersey (JAX-RS) Server/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/Java Jersey (JAX-RS) Server/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>java-jersey--jax-rs--server</artifactId>
+	<name>GenTarget Launcher For Java Jersey (JAX-RS) Server</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>Java Jersey (JAX-RS) Server</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/JavaScript Client/JavaScript Client.gen
+++ b/gentargets/Eclipse Marketplace API Specification/JavaScript Client/JavaScript Client.gen
@@ -1,0 +1,88 @@
+---
+name: "JavaScript Client"
+genTemplateId: "com.reprezen.genflow.openapi.generator.JavascriptClientCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # Sort method arguments to place required parameters before optional parameters.
+  sortParamsByRequiredFlag: null
+  
+  # Whether to ensure parameter names are unique in an operation (rename parameters that are not).
+  ensureUniqueParams: null
+  
+  # boolean, toggles whether unicode identifiers are allowed in names or not, default is false
+  allowUnicodeIdentifiers: null
+  
+  # Add form or body parameters to the beginning of the parameter list.
+  prependFormOrBodyParameters: null
+  
+  # source folder for generated code
+  sourceFolder: null
+  
+  # prefix for generated code members and local variables
+  localVariablePrefix: null
+  
+  # root package for generated code
+  invokerPackage: null
+  
+  # package for generated api classes
+  apiPackage: null
+  
+  # package for generated models
+  modelPackage: null
+  
+  # name of the project (Default: generated from info.title or "openapi-js-client")
+  projectName: null
+  
+  # module name for AMD, Node or globals (Default: generated from <projectName>)
+  moduleName: null
+  
+  # description of the project (Default: using info.description or "Client library of <projectName>")
+  projectDescription: null
+  
+  # version of the project (Default: using info.version or "1.0.0")
+  projectVersion: null
+  
+  # name of the license the project uses (Default: using info.license.name)
+  licenseName: null
+  
+  # use Promises as return values from the client API, instead of superagent callbacks
+  usePromises: null
+  
+  # generate getters and setters for model properties
+  emitModelMethods: null
+  
+  # generate JSDoc comments
+  emitJSDoc: null
+  
+  # use JavaScript prototype chains & delegation for inheritance
+  useInheritance: null
+  
+  # Hides the generation timestamp when files are generated.
+  hideGenerationTimestamp: null
+  
+  # use JavaScript ES6 (ECMAScript 6) (beta). Default is ES5.
+  useES6: null
+  
+  # Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name
+  modelPropertyNaming: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/JavaScript Client/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/JavaScript Client/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\JavaScript Client\\JavaScript Client.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/JavaScript Client/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/JavaScript Client/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>javascript-client</artifactId>
+	<name>GenTarget Launcher For JavaScript Client</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>JavaScript Client</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/Objective-C Client/Objective-C Client.gen
+++ b/gentargets/Eclipse Marketplace API Specification/Objective-C Client/Objective-C Client.gen
@@ -1,0 +1,49 @@
+---
+name: "Objective-C Client"
+genTemplateId: "com.reprezen.genflow.openapi.generator.ObjcClientCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # Should generate core data models
+  coreData: null
+  
+  # prefix for generated classes (convention: Abbreviation of pod name e.g. `HN` for `HackerNews`).`
+  classPrefix: null
+  
+  # cocoapods package name (convention: CameCase).
+  podName: null
+  
+  # cocoapods package version.
+  podVersion: null
+  
+  # Name to use in the podspec file.
+  authorName: null
+  
+  # Email to use in the podspec file.
+  authorEmail: null
+  
+  # URL for the git repo where this podspec should point to.
+  gitRepoURL: null
+  
+  # Hides the generation timestamp when files are generated.
+  hideGenerationTimestamp: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/Objective-C Client/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/Objective-C Client/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\Objective-C Client\\Objective-C Client.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/Objective-C Client/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/Objective-C Client/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>objective-c-client</artifactId>
+	<name>GenTarget Launcher For Objective-C Client</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>Objective-C Client</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/RepreZen HTML Documentation/RepreZen HTML Documentation.gen
+++ b/gentargets/Eclipse Marketplace API Specification/RepreZen HTML Documentation/RepreZen HTML Documentation.gen
@@ -1,0 +1,15 @@
+---
+name: "RepreZen HTML Documentation"
+genTemplateId: "com.reprezen.genflow.openapi3.doc.XOpenApi3DocGenTemplate"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # Set to false to suppress component model names in allOf models
+  showAllOfComponentModels: "true"
+  
+  # Set to false to suppress table of contents
+  includeTableOfContents: "true"

--- a/gentargets/Eclipse Marketplace API Specification/RepreZen HTML Documentation/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/RepreZen HTML Documentation/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\RepreZen HTML Documentation\\RepreZen HTML Documentation.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/RepreZen HTML Documentation/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/RepreZen HTML Documentation/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>reprezen-html-documentation</artifactId>
+	<name>GenTarget Launcher For RepreZen HTML Documentation</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>RepreZen HTML Documentation</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/gentargets/Eclipse Marketplace API Specification/Ruby Client/Ruby Client.gen
+++ b/gentargets/Eclipse Marketplace API Specification/Ruby Client/Ruby Client.gen
@@ -1,0 +1,70 @@
+---
+name: "Ruby Client"
+genTemplateId: "com.reprezen.genflow.openapi.generator.RubyClientCodegen"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "../../../models/Eclipse Marketplace API Specification.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # Sort method arguments to place required parameters before optional parameters.
+  sortParamsByRequiredFlag: null
+  
+  # Whether to ensure parameter names are unique in an operation (rename parameters that are not).
+  ensureUniqueParams: null
+  
+  # boolean, toggles whether unicode identifiers are allowed in names or not, default is false
+  allowUnicodeIdentifiers: null
+  
+  # Add form or body parameters to the beginning of the parameter list.
+  prependFormOrBodyParameters: null
+  
+  # gem name (convention: underscore_case).
+  gemName: null
+  
+  # top module name (convention: CamelCase, usually corresponding to gem name).
+  moduleName: null
+  
+  # gem version.
+  gemVersion: null
+  
+  # gem license.
+  gemLicense: null
+  
+  # gem required Ruby version.
+  gemRequiredRubyVersion: null
+  
+  # gem homepage.
+  gemHomepage: null
+  
+  # gem summary.
+  gemSummary: null
+  
+  # gem description.
+  gemDescription: null
+  
+  # gem author (only one is supported).
+  gemAuthor: null
+  
+  # gem author email (only one is supported).
+  gemAuthorEmail: null
+  
+  # Hides the generation timestamp when files are generated.
+  hideGenerationTimestamp: null
+  
+  # Contents of OpenAPI Generator configuration file.
+  # This is the file that would be passed with the --config option on the OpenAPI Generator
+  # command line. The JSON contents of that file should be the value of this parameter.
+  # This parameter need not be used. If it is absent, all string-valued parameters are collected into
+  # a map that is then passed to the OpenAPI Generator module. If a map is provided here, then
+  # string-valued parameters are still copied in, overriding like-named values appearing in the map.
+  openApiCodegenConfig: null
+  
+  # System properties to set, as in the -D option of OpenAPI Generator command line.
+  # Each property should be a JSON object with a name/value pair for each property.
+  # Example: for '-Dmodels -Dapis=User,Pets' use the following:
+  # value:
+  #   models: ''
+  #   apis: Users,Pets
+  openApiCodegenSystemProperties: null

--- a/gentargets/Eclipse Marketplace API Specification/Ruby Client/build.gradle
+++ b/gentargets/Eclipse Marketplace API Specification/Ruby Client/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+
+	repositories {
+		mavenLocal()
+		mavenCentral()
+	}
+	
+	dependencies {
+		compile group: 'com.reprezen.genflow', name: 'standard-gentemplates', version: '[1.3.0,2.0-alpha)'
+		compile group: 'io.swagger', name: 'swagger-codegen', version: '[2.4.0,3.0-alpha)'
+		compile group: 'org.openapitools', name: 'openapi-generator', version: '[3.3.4,4.0-alpha)'
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2/shared/GenTemplates', include: ['*.jar'])
+		compile fileTree(dir: 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\lib', include: ['*.jar'])
+	}
+	
+	task(execGenTarget, dependsOn: 'classes', type: JavaExec) {
+		main = 'com.reprezen.genflow.api.util.GeneratorLauncher'
+		classpath = sourceSets.main.runtimeClasspath
+		args 'C:\\Users\\tedep\\RepreZen\\workspace\\Demo2\\Eclipse Marketplace API v2\\gentargets\\Eclipse Marketplace API Specification\\Ruby Client\\Ruby Client.gen'
+	}
+	
+	defaultTasks 'execGenTarget' 

--- a/gentargets/Eclipse Marketplace API Specification/Ruby Client/pom.xml
+++ b/gentargets/Eclipse Marketplace API Specification/Ruby Client/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.your.company.genflow</groupId>
+		<artifactId>eclipse-marketplace-api-v2</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..\..\..\pom.xml</relativePath>
+	</parent>
+	<artifactId>ruby-client</artifactId>
+	<name>GenTarget Launcher For Ruby Client</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.lib.dir>C:/Users/tedep/RepreZen/workspace/Demo2/Eclipse Marketplace API v2/lib</project.lib.dir>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<build>
+		<defaultGoal>clean generate-sources</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.addjars-maven-plugin</groupId>
+				<artifactId>addjars-maven-plugin</artifactId>
+				<version>1.0.5</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-jars</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${shared.gentemplates.dir}</directory>
+								</resource>
+								<resource>
+									<directory>${project.lib.dir}</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includeProjectDependencies>true</includeProjectDependencies>
+					<mainClass>com.reprezen.genflow.api.util.GeneratorLauncher</mainClass>
+					<classpathScope>compile</classpathScope>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+					<arguments>
+						<argument>Ruby Client</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+</build>
+</project>

--- a/models/Eclipse Marketplace API Specification.yaml
+++ b/models/Eclipse Marketplace API Specification.yaml
@@ -1,0 +1,145 @@
+---
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: My API Spec
+  
+servers:
+- url: http://marketplace.eclipse.org/api/v2
+  description: Production endpoint for Eclipse Marketplace API
+
+paths:
+  /listings:
+    get:
+      parameters:
+      - name: licenseType
+        in: query
+        description: | 
+          Optional query parameter to filter the results by license type.
+          The result will be a union of all included license types. 
+          Valid values include:
+          
+          * **COMMERCIAL**  
+            Includes all commercial license types
+          * OPEN_SOURCE # Includes all open source license types
+          * EPL # Includes all versions of the [Eclipse Public License](http://eclipse.org/epl)
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - COMMERCIAL # Includes all commercial license types
+            - OPEN_SOURCE # Includes all open source license types
+            - EPL # Includes all versions of EPL
+            - EPL 1.0
+            - EPL 2.0
+            - GPL
+            
+        style: form
+        explode: true
+        
+      responses:
+        200:
+          description: Success
+
+  /listings/{listingID}:
+    parameters:
+    - name: listingID
+      in: path
+      description: Unique ID of an individual listing
+      required: true
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+      
+    get:
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Listing"
+                
+
+components:
+
+  schemas:
+    
+    Listings:
+      type: array
+      items: 
+        $ref: "#/components/schemas/Listing"
+    
+    Listing:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/ObjectID"
+        name:
+          type: string
+          description: Listing Title
+        categories:
+          type: array
+          items: 
+            $ref: "#/components/schemas/Category"
+          description: Array of categories in which this listing appears.
+    
+    Category:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/ObjectID"
+        name:
+          type: string
+          description: Category title
+        URL:
+          type: string
+          description: URL to retrieve the category details.
+          
+    ObjectID:
+      description: Unique identifier for an addressable object in the API.
+      type: integer
+      format: int32
+      minimum: 1           
+          
+      #(@attribute) name: [string] Listing Title
+      #(@attribute) url: [string] Listing Url
+      #type: [string] This is the type of listing being returned. 'training' is for a Training and Consulting Listing, 'resource' is for a solutions listing.
+      #categories
+      #category
+      #(@attribute) id: [int] Unique identifier
+      #(@attribute) name: [string] Title
+      #(@attribute) url: [string] Url
+      #tags
+      #tag
+      #(@attribute) id: [int] Unique identifier
+      #(@attribute) name: [string] Title
+      #(@attribute) url: [string] Url
+      #owner: [string] Name of the author
+      #favorited: [int] Number of times a listing was favorited
+      #installstotal: [int] Install count
+      #installsrecent: [int] Install count for the last month
+      #shortdescription: [string] Listing teaser
+      #body: [sting] Full description
+      #created: [int] Timestamp
+      #changed: [int] Timestamp
+      #foundationmember: [bool] TRUE/FALSE
+      #homepageurl: [string] Listing URL website
+      #image: [string] Logo absolute URL
+      #license: [string] Listing license
+      #companyname: [string] Company name
+      #status: [string] Release status
+      #supporturl: [string] Support/documentation URL
+      #version: [string] Version name
+      #eclipseversion: [float] Eclipse release number (4.5, 4.4...)
+      #updateurl: [string] Update site URL
+      #ius: Feature ID's are used by the Eclipse Marketplace Client (MPC) to determine which features to install for your listing https://marketplace-staging.eclipse.org/feature-how-to
+      #iu
+      #(@attribute) required: [string] TRUE or FALSE
+      #(@attribute) selected: [string] TRUE or FALSE
+      #platforms
+      #platform: [string] Compatible OS (Windows, Mac, Linux/GTK)    
+          

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   	<modelVersion>4.0.0</modelVersion>
+   	<groupId>com.your.company.genflow</groupId>
+   	<artifactId>eclipse-marketplace-api-v2</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<name>Eclipse Marketplace API v2</name>
+	<packaging>pom</packaging>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<shared.gentemplates.dir>C:\Users\tedep\RepreZen\workspace\Demo2/shared/GenTemplates</shared.gentemplates.dir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>com.reprezen.genflow</groupId>
+			<artifactId>standard-gentemplates</artifactId>
+			<version>[1.3.0,2.0-alpha)</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger</groupId>
+			<artifactId>swagger-codegen</artifactId>
+			<version>[2.4.0,3.0-alpha)</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openapitools</groupId>
+			<artifactId>openapi-generator</artifactId>
+			<version>[3.3.4,4.0-alpha)</version>
+		</dependency>
+	</dependencies>
+	<repositories>
+	</repositories>
+</project>


### PR DESCRIPTION
This commit has the prototype from our first working session. It includes:
* The core OpenAPI specification document in /models
* Sample of generated server stubs, client libraries and documentation formats in the /gentargets subfolders
* Project and build files for Eclipse with RepreZen API Studio. 

I also added some updates to the README with a brief introduction and some information on the development environment. Trying to be helpful to community members who want to contribute, without being opportunistic.  Please review and feel free to suggest changes.