### PR TITLE
Fix #33 - created/changed as date-time

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -896,9 +896,7 @@ components:
           type: string
           description: URL to retrieve the market details.
         categories:
-          type: array
-          items: 
-            $ref: "#/components/schemas/Categories"
+          $ref: "#/components/schemas/Categories"
           description: Array of categories that are used for the current market
         listing_ids:
           type: array

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -812,8 +812,9 @@ components:
           type: string
           description: Listing license
         organization:
-          $ref: "#/components/schemas/Organization"
           description: Organizations involved with the development of the listing
+          allOf:
+            - $ref: "#/components/schemas/Organization"
         status:
           type: string
           description: Release status
@@ -852,8 +853,9 @@ components:
           type: string
           description: Organization name
         id:
-          $ref: "#/components/schemas/ObjectID"
           description: Organizational member ID
+          allOf:
+            - $ref: "#/components/schemas/ObjectID"
 
     Tag:
       type: object
@@ -896,8 +898,9 @@ components:
           type: string
           description: URL to retrieve the market details.
         categories:
-          $ref: "#/components/schemas/Categories"
           description: Array of categories that are used for the current market
+          allOf:
+            - $ref: "#/components/schemas/Categories"
         listing_ids:
           type: array
           items: 
@@ -1008,7 +1011,8 @@ components:
           $ref: "#/components/schemas/ObjectID"
         listing_id:
           description: The listing ID this listing version represents
-          $ref: "#/components/schemas/ObjectID"
+          allOf:
+            - $ref: "#/components/schemas/ObjectID"
         version:
           type: string
           description: Version name string
@@ -1045,11 +1049,13 @@ components:
           type: string
           description: The OS detected for the record
         version:
-          $ref: "#/components/schemas/ObjectID"
           description: ID of the Listing version that was installed
+          allOf:
+            - $ref: "#/components/schemas/ObjectID"
         listing_id:
-          $ref: "#/components/schemas/ObjectID"
           description: ID of the Listing that was installed
+          allOf:
+            - $ref: "#/components/schemas/ObjectID"
         java_version:
           type: string
           description: Detected Java version for this record

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -960,12 +960,15 @@ components:
           type: string
           description: URL for default content of the tab
         type:
-          type: string
-          description: Type of tab, can either be a default tab, a search tab, or an embedded content tab
-          enum:
-            - default
-            - search
-            - embedded
+          $ref: "#/components/schemas/catalog_tab_type"
+
+    catalog_tab_type:
+      type: string
+      description: Type of tab, can either be a default tab, a search tab, or an embedded content tab
+      enum:
+        - default
+        - search
+        - embedded
 
     license_type:
       type: string
@@ -1104,12 +1107,15 @@ components:
           type: string
           description: The ID of the feature for the solution
         install_state:
-          type: string
-          description: Whether the feature is required, optional, or recommended.
-          enum:
-            - optional
-            - required
-            - optional_selected    
+          $ref: "#/components/schemas/install_state"
+
+    install_state:
+      type: string
+      description: Whether the feature is required, optional, or recommended.
+      enum:
+        - optional
+        - required
+        - optional_selected
     
     Installs:
       type: object

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -792,12 +792,12 @@ components:
           type: string
           description: Full description
         created:
-          type: integer
-          format: int64
+          type: string
+          format: date-time
           description: Timestamp
         changed:
-          type: integer
-          format: int64
+          type: string
+          format: date-time
           description: Timestamp
         foundation_member:
           type: boolean


### PR DESCRIPTION
This fixes #33: it changes the `created`/`changed` properties of Listing to string/date-time (timestamp in ISO-8601 format, e.g. 2021-07-01T18:54:30Z). This is what the server already returns despite the spec currently defining int64.

Also a few additional fixes for the spec:
* Market.categories array was wrong (one array too many)
* Named enums, so generated clients have a better time with them
* Validity issues with $ref